### PR TITLE
Centralize Auth Redirect Logic in AuthLayout Component

### DIFF
--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -1,12 +1,38 @@
+"use client";
+
 import { Icons } from "@/components/icons";
 import Link from "next/link";
 import Image from "next/image";
+import { useRouter } from "next/navigation";
+import { useEffect } from "react";
 
 export default function AuthLayout({
   children,
 }: {
   children: React.ReactNode;
 }) {
+  const router = useRouter();
+
+  // Redirect if already logged in
+  useEffect(() => {
+    async function checkAuth() {
+      try {
+        const response = await fetch('/api/users/me', {
+          credentials: 'include',
+        });
+        
+        if (response.ok) {
+          // User is already authenticated, redirect to projects
+          router.push('/projects');
+        }
+      } catch {
+        // User is not authenticated, stay on auth page
+      }
+    }
+
+    checkAuth();
+  }, [router]);
+
   return (
     <div className="min-h-screen grid lg:grid-cols-2">
       {/* Left side - Branding */}

--- a/src/app/(auth)/layout.tsx
+++ b/src/app/(auth)/layout.tsx
@@ -4,7 +4,7 @@ import { Icons } from "@/components/icons";
 import Link from "next/link";
 import Image from "next/image";
 import { useRouter } from "next/navigation";
-import { useEffect } from "react";
+import { useEffect, useState } from "react";
 
 export default function AuthLayout({
   children,
@@ -12,6 +12,7 @@ export default function AuthLayout({
   children: React.ReactNode;
 }) {
   const router = useRouter();
+  const [isChecking, setIsChecking] = useState(true);
 
   // Redirect if already logged in
   useEffect(() => {
@@ -24,14 +25,30 @@ export default function AuthLayout({
         if (response.ok) {
           // User is already authenticated, redirect to projects
           router.push('/projects');
+          return;
         }
+
+        setIsChecking(false);
       } catch {
         // User is not authenticated, stay on auth page
+        setIsChecking(false);
       }
     }
 
     checkAuth();
   }, [router]);
+
+  // Show loading state while checking authentication
+  if (isChecking) {
+    return (
+      <div className="flex h-screen items-center justify-center">
+        <div className="flex flex-col items-center gap-2">
+          <div className="h-8 w-8 animate-spin rounded-full border-4 border-primary border-t-transparent" />
+          <p className="text-sm text-muted-foreground">Verifying authentication...</p>
+        </div>
+      </div>
+    );
+  }
 
   return (
     <div className="min-h-screen grid lg:grid-cols-2">

--- a/src/app/(auth)/login/page.tsx
+++ b/src/app/(auth)/login/page.tsx
@@ -34,26 +34,6 @@ export default function LoginPage() {
     checkConfig();
   }, []);
 
-  // Redirect if already logged in
-  React.useEffect(() => {
-    async function checkAuth() {
-      try {
-        const response = await fetch('/api/users/me', {
-          credentials: 'include',
-        });
-        
-        if (response.ok) {
-          // User is already authenticated, redirect to projects
-          router.push('/projects');
-        }
-      } catch {
-        // User is not authenticated, stay on login page
-      }
-    }
-
-    checkAuth();
-  }, [router]);
-
   async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setIsLoading(true);

--- a/src/app/(auth)/signup/page.tsx
+++ b/src/app/(auth)/signup/page.tsx
@@ -37,26 +37,6 @@ export default function SignupPage() {
     checkConfig();
   }, []);
 
-  // Redirect if already logged in
-  React.useEffect(() => {
-    async function checkAuth() {
-      try {
-        const response = await fetch('/api/users/me', {
-          credentials: 'include',
-        });
-        
-        if (response.ok) {
-          // User is already authenticated, redirect to projects
-          router.push('/projects');
-        }
-      } catch {
-        // User is not authenticated, stay on signup page
-      }
-    }
-
-    checkAuth();
-  }, [router]);
-
   async function onSubmit(event: React.FormEvent<HTMLFormElement>) {
     event.preventDefault();
     setIsLoading(true);


### PR DESCRIPTION
This PR moves the authentication check and redirect logic from the individual LoginPage and SignupPage components into the shared AuthLayout component.

# Changes
- **AuthLayout:**
  - Added a useEffect hook to check if the user is already authenticated via /api/users/me.
  - If authenticated, automatically redirects to /projects.
- **LoginPage & SignupPage:**
  - Removed redundant authentication checks and redirects, as these are now handled by the layout.