### PR TITLE
Update lint-typecheck workflow triggers

### DIFF
--- a/.github/workflows/lint-typecheck.yml
+++ b/.github/workflows/lint-typecheck.yml
@@ -2,11 +2,15 @@ name: Lint & Typecheck
 
 on:
   pull_request:
-    branches:
-      - "**"
+    types:
+      - opened
+      - reopened
+      - synchronize
+      - ready_for_review
 
 jobs:
-  lint:
+  lint-typecheck:
+    if: ${{ !github.event.pull_request.draft }}
     runs-on: ubuntu-latest
 
     steps:


### PR DESCRIPTION
- The "Lint & Typecheck" action now only runs in PR's that are ready for review.
- Renamed the job id from "lint" to "lint-typecheck".